### PR TITLE
Add kube-test make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .direnv
 .envrc
 corgi
+opensearch-values.yaml

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ IMAGE_TAG ?= latest
 .PHONY: all
 all: test
 
+include Makefile.OpenSearch
+
 corgi: $(shell find . -iname "*.go") # Build the main binary
 	CGO_ENABLED=0 $(GO) build $(GO_BUILD_FLAGS) \
 			    -mod=vendor \
@@ -18,3 +20,36 @@ test: corgi # Build and run the tests
 .PHONY: clean
 clean: # Clean the local generated artifacts
 	rm -fr -- corgi
+
+.PHONY: kube-test
+kube-test: opensearch-values.yaml # Set up a kube environment with opensearch
+	kubectl create namespace corgi-test \
+		--dry-run=client -o yaml \
+	| kubectl apply -f -
+	helm repo add opensearch https://opensearch-project.github.io/helm-charts/
+	helm repo update
+	helm upgrade opensearch opensearch/opensearch \
+		--install \
+		--namespace corgi-test \
+		--values opensearch-values.yaml
+	helm upgrade opensearch-dashboards opensearch/opensearch-dashboards \
+		--install \
+		--namespace corgi-test
+	>&2 echo
+	>&2 echo "You can use 'make kube-port-forward' to expose opensearch ports locally"
+
+.PHONY: kube-port-forward
+kube-port-forward: opensearch-ready # Port-forward access to opensearch into the host
+	-@pkill -f 'port-forward opensearch.*corgi-test'
+	$(eval KOS_SERV=$(shell kubectl get pods --namespace corgi-test -l "app.kubernetes.io/name=opensearch" -o jsonpath="{.items[0].metadata.name}"))
+	$(eval KOS_SERV_PORT=$(shell kubectl get pod --namespace corgi-test $(KOS_SERV) -o jsonpath="{.spec.containers[0].ports[0].containerPort}"))
+	kubectl port-forward $(KOS_SERV) 9200:$(KOS_SERV_PORT) \
+		--namespace=corgi-test \
+		--address 127.0.0.1 \
+		&
+	$(eval KOS_DASH=$(shell kubectl get pods --namespace corgi-test -l "app.kubernetes.io/name=opensearch-dashboards" -o jsonpath="{.items[0].metadata.name}"))
+	$(eval KOS_DASH_PORT=$(shell kubectl get pod --namespace corgi-test $(KOS_DASH) -o jsonpath="{.spec.containers[0].ports[0].containerPort}"))
+	kubectl port-forward $(KOS_DASH) 5601:$(KOS_DASH_PORT) \
+		--namespace=corgi-test \
+		--address 127.0.0.1 \
+		&

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,15 @@ IMAGE_TAG ?= latest
 .PHONY: all
 all: test
 
-corgi: $(shell find . -iname "*.go")
+corgi: $(shell find . -iname "*.go") # Build the main binary
 	CGO_ENABLED=0 $(GO) build $(GO_BUILD_FLAGS) \
 			    -mod=vendor \
 			    -o $@ .
 
 .PHONY: test
-test: corgi
+test: corgi # Build and run the tests
 	$(GO) test -mod=vendor ./...
 
 .PHONY: clean
-clean:
+clean: # Clean the local generated artifacts
 	rm -fr -- corgi

--- a/Makefile.OpenSearch
+++ b/Makefile.OpenSearch
@@ -1,0 +1,24 @@
+.PHONY: all test clean
+
+OPENSEARCH_INITIAL_ADMIN_PASSWORD ?= $(shell openssl rand -base64 16)
+
+define newline
+
+
+endef
+
+define OPENSEARCH_VALUES_YAML
+extraEnvs:
+  - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+    value: $(OPENSEARCH_INITIAL_ADMIN_PASSWORD)
+endef
+
+opensearch-values.yaml: Makefile.OpenSearch # Generate an OpenSearch values.yaml file for testing
+	echo '$(subst $(newline),\n,${OPENSEARCH_VALUES_YAML})' > $@
+
+.PHONY: opensearch-ready
+opensearch-ready: # Wait for OpenSearch to be ready
+	kubectl rollout status statefulset.apps/opensearch-cluster-master \
+		--namespace=corgi-test \
+		--timeout=60s \
+		--watch


### PR DESCRIPTION
This should help with locally bootstrapping an environment for testing.

New make targets:
- kube-test - Deploy OpenSearch into kubernetes (via your current KUBECONFIG)
- kube-port-forward - Port forward the OpenSearch and OpenSearch dashboards

Commits:
- **Makefile: Add comments for existing targets**
- **Makefile: Add bootstrap for OpenSearch in k8s**

Notably, running these targets will generate `opensearch-values.yaml` which includes the password you need to log into the deployed OpenSearch instance.