### PR TITLE
junit: Fix parsing junit without owners

### DIFF
--- a/pkg/junit/junit.go
+++ b/pkg/junit/junit.go
@@ -164,13 +164,13 @@ func parseTestsuite(
 		if testcase.Failure != nil {
 			// Parse owners
 			owners, testNames, err := parseFailureData(testcase.Failure.Data)
-			if err != nil {
+			if err == nil {
+				tc.Owners = filterTestOwners(owners, testNames)
+				for _, o := range filterWorkflowOwners(owners, testNames) {
+					allOwners[o] = struct{}{}
+				}
+			} else {
 				l.Warn("Could not parse owners from testcase failure data", "data", testcase.Failure.Data, "error", err)
-				continue
-			}
-			tc.Owners = filterTestOwners(owners, testNames)
-			for _, o := range filterWorkflowOwners(owners, testNames) {
-				allOwners[o] = struct{}{}
 			}
 		}
 


### PR DESCRIPTION
If the owners are missing, it would trigger a parse error which was
previously causing the test case to be skipped instead of being added to
the output. Fix it by just continuing if owners can't be determined.
