### PR TITLE
Add support for codeowners on passing test cases

### DIFF
--- a/pkg/junit/junit.go
+++ b/pkg/junit/junit.go
@@ -14,8 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jstemmer/go-junit-report/v2/junit"
-
 	"github.com/isovalent/corgi/pkg/types"
 	"github.com/isovalent/corgi/pkg/util"
 )
@@ -80,7 +78,7 @@ func filterTestOwners(owners, tests []string) []string {
 }
 
 func parseTestsuite(
-	suite *junit.Testsuite,
+	suite *Testsuite,
 	run *types.WorkflowRun,
 	allowedTestConclusions []string,
 	l *slog.Logger,
@@ -229,10 +227,10 @@ func parseFile(
 	// Try all options when unmarshalling.
 	// Note that the XML parser thinks the Testsuites object is a valid Testsuite object, so
 	// we have to try parsing into a Testsuites first.
-	toParse := []junit.Testsuite{}
-	s := junit.Testsuites{}
+	toParse := []Testsuite{}
+	s := Testsuites{}
 	if err := xml.Unmarshal(buf.Bytes(), &s); err != nil {
-		s := junit.Testsuite{}
+		s := Testsuite{}
 		if err2 := xml.Unmarshal(buf.Bytes(), &s); err2 != nil {
 			e := errors.Join(err, err2)
 			return nil, nil, fmt.Errorf("unable to unmarshal junit file '%s' in artifact to Testsuite or Testsuites object: %w", fil.FileInfo().Name(), e)

--- a/pkg/junit/junit_test.go
+++ b/pkg/junit/junit_test.go
@@ -107,6 +107,22 @@ func TestParseTestSuiteCodeOwners(t *testing.T) {
 	assert.NotEmpty(t, failed.Owners)
 }
 
+func TestParseProperties(t *testing.T) {
+	path := "testdata/all-owners.xml"
+
+	f, err := NewTestFile(path)
+	assert.NoError(t, err)
+	_, cases, err := parseFile(f, dummyWorkflowRun, dummyConclusions, logger)
+	assert.NoError(t, err)
+
+	// Example has no workflow owners
+	//assert.NotEmpty(t, suites[0].Owners)
+
+	for _, tt := range cases {
+		assert.NotEmpty(t, tt.Owners)
+	}
+}
+
 func TestFilterOwners(t *testing.T) {
 	input := "check-log-errors/no-errors-in-logs/kind-kind/kube-system/cilium-xxxxx (cilium-agent);metadata;Owners: @ci/owner1 (no-errors-in-logs), @ci/owner2 (.github/foo)"
 

--- a/pkg/junit/suites.go
+++ b/pkg/junit/suites.go
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) Joel Stemmer
+
+// Package junit defines a JUnit XML report and includes convenience methods
+// for working with these reports.
+package junit
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/jstemmer/go-junit-report/v2/gtr"
+)
+
+// Testsuites is a collection of JUnit testsuites.
+type Testsuites struct {
+	XMLName xml.Name `xml:"testsuites"`
+
+	Name     string `xml:"name,attr,omitempty"`
+	Time     string `xml:"time,attr,omitempty"` // total duration in seconds
+	Tests    int    `xml:"tests,attr,omitempty"`
+	Errors   int    `xml:"errors,attr,omitempty"`
+	Failures int    `xml:"failures,attr,omitempty"`
+	Skipped  int    `xml:"skipped,attr,omitempty"`
+	Disabled int    `xml:"disabled,attr,omitempty"`
+
+	Suites []Testsuite `xml:"testsuite,omitempty"`
+}
+
+// AddSuite adds a Testsuite and updates this testssuites' totals.
+func (t *Testsuites) AddSuite(ts Testsuite) {
+	t.Suites = append(t.Suites, ts)
+	t.Tests += ts.Tests
+	t.Errors += ts.Errors
+	t.Failures += ts.Failures
+	t.Skipped += ts.Skipped
+	t.Disabled += ts.Disabled
+}
+
+// WriteXML writes the XML representation of Testsuites t to writer w.
+func (t *Testsuites) WriteXML(w io.Writer) error {
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "\t")
+	if err := enc.Encode(t); err != nil {
+		return err
+	}
+	if err := enc.Flush(); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(w, "\n")
+	return err
+}
+
+// Testsuite is a single JUnit testsuite containing testcases.
+type Testsuite struct {
+	// required attributes
+	Name     string `xml:"name,attr"`
+	Tests    int    `xml:"tests,attr"`
+	Failures int    `xml:"failures,attr"`
+	Errors   int    `xml:"errors,attr"`
+	ID       int    `xml:"id,attr"`
+
+	// optional attributes
+	Disabled  int    `xml:"disabled,attr,omitempty"`
+	Hostname  string `xml:"hostname,attr,omitempty"`
+	Package   string `xml:"package,attr,omitempty"`
+	Skipped   int    `xml:"skipped,attr,omitempty"`
+	Time      string `xml:"time,attr"`                // duration in seconds
+	Timestamp string `xml:"timestamp,attr,omitempty"` // date and time in ISO8601
+	File      string `xml:"file,attr,omitempty"`
+
+	Properties *[]Property `xml:"properties>property,omitempty"`
+	Testcases  []Testcase  `xml:"testcase,omitempty"`
+	SystemOut  *Output     `xml:"system-out,omitempty"`
+	SystemErr  *Output     `xml:"system-err,omitempty"`
+}
+
+// AddProperty adds a property with the given name and value to this Testsuite.
+func (t *Testsuite) AddProperty(name, value string) {
+	prop := Property{Name: name, Value: value}
+	if t.Properties == nil {
+		t.Properties = &[]Property{prop}
+		return
+	}
+	props := append(*t.Properties, prop)
+	t.Properties = &props
+}
+
+// AddTestcase adds Testcase tc to this Testsuite.
+func (t *Testsuite) AddTestcase(tc Testcase) {
+	t.Testcases = append(t.Testcases, tc)
+	t.Tests++
+
+	if tc.Error != nil {
+		t.Errors++
+	}
+
+	if tc.Failure != nil {
+		t.Failures++
+	}
+
+	if tc.Skipped != nil {
+		t.Skipped++
+	}
+}
+
+// SetTimestamp sets the timestamp in this Testsuite.
+func (t *Testsuite) SetTimestamp(timestamp time.Time) {
+	t.Timestamp = timestamp.Format(time.RFC3339)
+}
+
+// Testcase represents a single test with its results.
+type Testcase struct {
+	// required attributes
+	Name      string `xml:"name,attr"`
+	Classname string `xml:"classname,attr"`
+
+	// optional attributes
+	Time   string `xml:"time,attr,omitempty"` // duration in seconds
+	Status string `xml:"status,attr,omitempty"`
+
+	Skipped   *Result `xml:"skipped,omitempty"`
+	Error     *Result `xml:"error,omitempty"`
+	Failure   *Result `xml:"failure,omitempty"`
+	SystemOut *Output `xml:"system-out,omitempty"`
+	SystemErr *Output `xml:"system-err,omitempty"`
+}
+
+// Property represents a key/value pair.
+type Property struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// Result represents the result of a single test.
+type Result struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr,omitempty"`
+	Data    string `xml:",cdata"`
+}
+
+// Output represents output written to stdout or sderr.
+type Output struct {
+	Data string `xml:",cdata"`
+}
+
+// CreateFromReport creates a JUnit representation of the given gtr.Report.
+func CreateFromReport(report gtr.Report, hostname string) Testsuites {
+	var suites Testsuites
+	for _, pkg := range report.Packages {
+		var duration time.Duration
+		suite := Testsuite{
+			Name:     pkg.Name,
+			Hostname: hostname,
+			ID:       len(suites.Suites),
+		}
+
+		if !pkg.Timestamp.IsZero() {
+			suite.SetTimestamp(pkg.Timestamp)
+		}
+
+		for _, p := range pkg.Properties {
+			suite.AddProperty(p.Name, p.Value)
+		}
+
+		if len(pkg.Output) > 0 {
+			suite.SystemOut = &Output{Data: formatOutput(pkg.Output)}
+		}
+
+		if pkg.Coverage > 0 {
+			suite.AddProperty("coverage.statements.pct", fmt.Sprintf("%.2f", pkg.Coverage))
+		}
+
+		for _, test := range pkg.Tests {
+			duration += test.Duration
+			suite.AddTestcase(createTestcaseForTest(pkg.Name, test))
+		}
+
+		// JUnit doesn't have a good way of dealing with build or runtime
+		// errors that happen before a test has started, so we create a single
+		// failing test that contains the build error details.
+		if pkg.BuildError.Name != "" {
+			tc := Testcase{
+				Classname: pkg.BuildError.Name,
+				Name:      pkg.BuildError.Cause,
+				Time:      formatDuration(0),
+				Error: &Result{
+					Message: "Build error",
+					Data:    strings.Join(pkg.BuildError.Output, "\n"),
+				},
+			}
+			suite.AddTestcase(tc)
+		}
+
+		if pkg.RunError.Name != "" {
+			tc := Testcase{
+				Classname: pkg.RunError.Name,
+				Name:      "Failure",
+				Time:      formatDuration(0),
+				Error: &Result{
+					Message: "Runtime error",
+					Data:    strings.Join(pkg.RunError.Output, "\n"),
+				},
+			}
+			suite.AddTestcase(tc)
+		}
+
+		if (pkg.Duration) == 0 {
+			suite.Time = formatDuration(duration)
+		} else {
+			suite.Time = formatDuration(pkg.Duration)
+		}
+		suites.AddSuite(suite)
+	}
+	return suites
+}
+
+func createTestcaseForTest(pkgName string, test gtr.Test) Testcase {
+	tc := Testcase{
+		Classname: pkgName,
+		Name:      test.Name,
+		Time:      formatDuration(test.Duration),
+	}
+
+	if test.Result == gtr.Fail {
+		tc.Failure = &Result{
+			Message: "Failed",
+			Data:    formatOutput(test.Output),
+		}
+	} else if test.Result == gtr.Skip {
+		tc.Skipped = &Result{
+			Message: "Skipped",
+			Data:    formatOutput(test.Output),
+		}
+	} else if test.Result == gtr.Unknown {
+		tc.Error = &Result{
+			Message: "No test result found",
+			Data:    formatOutput(test.Output),
+		}
+	} else if len(test.Output) > 0 {
+		tc.SystemOut = &Output{Data: formatOutput(test.Output)}
+	}
+	return tc
+}
+
+// formatDuration returns the JUnit string representation of the given
+// duration.
+func formatDuration(d time.Duration) string {
+	return fmt.Sprintf("%.3f", d.Seconds())
+}
+
+// formatOutput combines the lines from the given output into a single string.
+func formatOutput(output []string) string {
+	return escapeIllegalChars(strings.Join(output, "\n"))
+}
+
+func escapeIllegalChars(str string) string {
+	return strings.Map(func(r rune) rune {
+		if isInCharacterRange(r) {
+			return r
+		}
+		return '\uFFFD'
+	}, str)
+}
+
+// Decide whether the given rune is in the XML Character Range, per
+// the Char production of https://www.xml.com/axml/testaxml.htm,
+// Section 2.2 Characters.
+// From: encoding/xml/xml.go
+func isInCharacterRange(r rune) (inrange bool) {
+	return r == 0x09 ||
+		r == 0x0A ||
+		r == 0x0D ||
+		r >= 0x20 && r <= 0xD7FF ||
+		r >= 0xE000 && r <= 0xFFFD ||
+		r >= 0x10000 && r <= 0x10FFFF
+}

--- a/pkg/junit/suites.go
+++ b/pkg/junit/suites.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) Joel Stemmer
+// Copyright (C) Isovalent, Inc.
 
 // Package junit defines a JUnit XML report and includes convenience methods
 // for working with these reports.
@@ -119,14 +120,20 @@ type Testcase struct {
 	Classname string `xml:"classname,attr"`
 
 	// optional attributes
-	Time   string `xml:"time,attr,omitempty"` // duration in seconds
-	Status string `xml:"status,attr,omitempty"`
+	Time       string      `xml:"time,attr,omitempty"` // duration in seconds
+	Status     string      `xml:"status,attr,omitempty"`
+	Properties *Properties `xml:"properties,omitempty"`
 
 	Skipped   *Result `xml:"skipped,omitempty"`
 	Error     *Result `xml:"error,omitempty"`
 	Failure   *Result `xml:"failure,omitempty"`
 	SystemOut *Output `xml:"system-out,omitempty"`
 	SystemErr *Output `xml:"system-err,omitempty"`
+}
+
+// Properties represents a slice of key/value pairs.
+type Properties struct {
+	Properties []Property `xml:"property"`
 }
 
 // Property represents a key/value pair.

--- a/pkg/junit/testdata/all-owners.xml
+++ b/pkg/junit/testdata/all-owners.xml
@@ -1,0 +1,734 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuites tests="115" disabled="114" errors="0" failures="1" time="0.343417843">
+      <testsuite name="connectivity test" id="0" package="cilium" tests="115" errors="0" failures="1" skipped="114" time="0.343417843" timestamp="0001-01-01T00:00:00">
+          <properties>
+              <property name="Args" value="--test|pod-to-pod-no-frag|--junit-file|codeowners.junit.xml|--log-code-owners"></property>
+          </properties>
+          <testcase name="no-unexpected-packet-drops" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (no-unexpected-packet-drops), @cilium/sig-datapath (no-unexpected-packet-drops)"></property>
+              </properties>
+              <skipped message="no-unexpected-packet-drops skipped"></skipped>
+          </testcase>
+          <testcase name="no-policies" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (host-to-pod)"></property>
+                  <property name="owner" value="@cilium/sig-policy (pod-to-cidr)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/ci-structure (client-to-client)"></property>
+                  <property name="owner" value="@cilium/sig-lb (pod-to-service)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-hostport)"></property>
+                  <property name="owner" value="@cilium/proxy (pod-to-world)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-host)"></property>
+              </properties>
+              <skipped message="no-policies skipped"></skipped>
+          </testcase>
+          <testcase name="no-policies-from-outside" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-policy (from-cidr-to-pod)"></property>
+              </properties>
+              <skipped message="no-policies-from-outside skipped"></skipped>
+          </testcase>
+          <testcase name="no-policies-extra" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-lb (pod-to-remote-nodeport)"></property>
+                  <property name="owner" value="@cilium/sig-lb (pod-to-local-nodeport)"></property>
+              </properties>
+              <skipped message="no-policies-extra skipped"></skipped>
+          </testcase>
+          <testcase name="allow-all-except-world" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/ci-structure (client-to-client)"></property>
+                  <property name="owner" value="@cilium/sig-lb (pod-to-service)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-host)"></property>
+              </properties>
+              <skipped message="allow-all-except-world skipped"></skipped>
+          </testcase>
+          <testcase name="client-ingress" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/ci-structure (client-to-client)"></property>
+              </properties>
+              <skipped message="client-ingress skipped"></skipped>
+          </testcase>
+          <testcase name="client-ingress-knp" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/ci-structure (client-to-client)"></property>
+              </properties>
+              <skipped message="client-ingress-knp skipped"></skipped>
+          </testcase>
+          <testcase name="allow-all-with-metrics-check" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="allow-all-with-metrics-check skipped"></skipped>
+          </testcase>
+          <testcase name="all-ingress-deny" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-policy (pod-to-cidr)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="all-ingress-deny skipped"></skipped>
+          </testcase>
+          <testcase name="all-ingress-deny-from-outside" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-policy (from-cidr-to-pod)"></property>
+              </properties>
+              <skipped message="all-ingress-deny-from-outside skipped"></skipped>
+          </testcase>
+          <testcase name="all-ingress-deny-knp" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/sig-policy (pod-to-cidr)"></property>
+              </properties>
+              <skipped message="all-ingress-deny-knp skipped"></skipped>
+          </testcase>
+          <testcase name="all-egress-deny" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod-with-endpoints)"></property>
+              </properties>
+              <skipped message="all-egress-deny skipped"></skipped>
+          </testcase>
+          <testcase name="all-egress-deny-knp" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod-with-endpoints)"></property>
+              </properties>
+              <skipped message="all-egress-deny-knp skipped"></skipped>
+          </testcase>
+          <testcase name="all-entities-deny" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/sig-policy (pod-to-cidr)"></property>
+              </properties>
+              <skipped message="all-entities-deny skipped"></skipped>
+          </testcase>
+          <testcase name="cluster-entity" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="cluster-entity skipped"></skipped>
+          </testcase>
+          <testcase name="cluster-entity-multi-cluster" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="cluster-entity-multi-cluster skipped"></skipped>
+          </testcase>
+          <testcase name="host-entity-egress" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-host)"></property>
+              </properties>
+              <skipped message="host-entity-egress skipped"></skipped>
+          </testcase>
+          <testcase name="host-entity-ingress" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (host-to-pod)"></property>
+              </properties>
+              <skipped message="host-entity-ingress skipped"></skipped>
+          </testcase>
+          <testcase name="echo-ingress" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="echo-ingress skipped"></skipped>
+          </testcase>
+          <testcase name="echo-ingress-from-outside" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-policy (from-cidr-to-pod)"></property>
+              </properties>
+              <skipped message="echo-ingress-from-outside skipped"></skipped>
+          </testcase>
+          <testcase name="echo-ingress-knp" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="echo-ingress-knp skipped"></skipped>
+          </testcase>
+          <testcase name="client-ingress-icmp" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/ci-structure (client-to-client)"></property>
+              </properties>
+              <skipped message="client-ingress-icmp skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-egress skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-knp" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-egress-knp skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-expression" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-egress-expression skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-expression-port-range" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-egress-expression-port-range skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-expression-knp" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-egress-expression-knp skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-expression-knp-port-range" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-egress-expression-knp-port-range skipped"></skipped>
+          </testcase>
+          <testcase name="client-with-service-account-egress-to-echo" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-with-service-account-egress-to-echo skipped"></skipped>
+          </testcase>
+          <testcase name="client-with-service-account-egress-to-echo-port-range" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-with-service-account-egress-to-echo-port-range skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-to-echo-service-account" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-egress-to-echo-service-account skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-to-echo-service-account-port-range" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-egress-to-echo-service-account-port-range skipped"></skipped>
+          </testcase>
+          <testcase name="to-entities-world" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/proxy (pod-to-world)"></property>
+              </properties>
+              <skipped message="to-entities-world skipped"></skipped>
+          </testcase>
+          <testcase name="to-entities-world-port-range" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/proxy (pod-to-world)"></property>
+              </properties>
+              <skipped message="to-entities-world-port-range skipped"></skipped>
+          </testcase>
+          <testcase name="to-cidr-external" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-policy (pod-to-cidr)"></property>
+              </properties>
+              <skipped message="to-cidr-external skipped"></skipped>
+          </testcase>
+          <testcase name="to-cidr-external-knp" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-policy (pod-to-cidr)"></property>
+              </properties>
+              <skipped message="to-cidr-external-knp skipped"></skipped>
+          </testcase>
+          <testcase name="seq-from-cidr-host-netns" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-policy (from-cidr-to-pod)"></property>
+              </properties>
+              <skipped message="seq-from-cidr-host-netns skipped"></skipped>
+          </testcase>
+          <testcase name="echo-ingress-from-other-client-deny" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/ci-structure (client-to-client)"></property>
+              </properties>
+              <skipped message="echo-ingress-from-other-client-deny skipped"></skipped>
+          </testcase>
+          <testcase name="client-ingress-from-other-client-icmp-deny" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/ci-structure (client-to-client)"></property>
+              </properties>
+              <skipped message="client-ingress-from-other-client-icmp-deny skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-to-echo-deny" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/ci-structure (client-to-client)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-egress-to-echo-deny skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-to-echo-deny-port-range" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/ci-structure (client-to-client)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-egress-to-echo-deny-port-range skipped"></skipped>
+          </testcase>
+          <testcase name="client-ingress-to-echo-named-port-deny" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-ingress-to-echo-named-port-deny skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-to-echo-expression-deny" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-egress-to-echo-expression-deny skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-to-echo-expression-deny-port-range" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-egress-to-echo-expression-deny-port-range skipped"></skipped>
+          </testcase>
+          <testcase name="client-with-service-account-egress-to-echo-deny" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-with-service-account-egress-to-echo-deny skipped"></skipped>
+          </testcase>
+          <testcase name="client-with-service-account-egress-to-echo-deny-port-range" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-with-service-account-egress-to-echo-deny-port-range skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-to-echo-service-account-deny" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-egress-to-echo-service-account-deny skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-to-echo-service-account-deny-port-range" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="client-egress-to-echo-service-account-deny-port-range skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-to-cidr-deny" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-policy (pod-to-cidr)"></property>
+              </properties>
+              <skipped message="client-egress-to-cidr-deny skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-to-cidrgroup-deny" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-policy (pod-to-cidr)"></property>
+              </properties>
+              <skipped message="client-egress-to-cidrgroup-deny skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-to-cidrgroup-deny-by-label" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-policy (pod-to-cidr)"></property>
+              </properties>
+              <skipped message="client-egress-to-cidrgroup-deny-by-label skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-to-cidr-deny-default" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-policy (pod-to-cidr)"></property>
+              </properties>
+              <skipped message="client-egress-to-cidr-deny-default skipped"></skipped>
+          </testcase>
+          <testcase name="clustermesh-endpointslice-sync" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-clustermesh (clustermesh-endpointslice-sync)"></property>
+              </properties>
+              <skipped message="clustermesh-endpointslice-sync skipped"></skipped>
+          </testcase>
+          <testcase name="health" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (cilium-health)"></property>
+              </properties>
+              <skipped message="health skipped"></skipped>
+          </testcase>
+          <testcase name="north-south-loadbalancing" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-lb (outside-to-nodeport)"></property>
+              </properties>
+              <skipped message="north-south-loadbalancing skipped"></skipped>
+          </testcase>
+          <testcase name="pod-to-pod-encryption" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-encryption (pod-to-pod-encryption)"></property>
+              </properties>
+              <skipped message="pod-to-pod-encryption skipped"></skipped>
+          </testcase>
+          <testcase name="pod-to-pod-with-l7-policy-encryption" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-encryption (pod-to-pod-encryption)"></property>
+              </properties>
+              <skipped message="pod-to-pod-with-l7-policy-encryption skipped"></skipped>
+          </testcase>
+          <testcase name="pod-to-pod-encryption-v2" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-encryption (pod-to-pod-encryption-v2)"></property>
+              </properties>
+              <skipped message="pod-to-pod-encryption-v2 skipped"></skipped>
+          </testcase>
+          <testcase name="pod-to-pod-with-l7-policy-encryption-v2" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-encryption (pod-to-pod-encryption-v2)"></property>
+              </properties>
+              <skipped message="pod-to-pod-with-l7-policy-encryption-v2 skipped"></skipped>
+          </testcase>
+          <testcase name="node-to-node-encryption" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-encryption (node-to-node-encryption)"></property>
+              </properties>
+              <skipped message="node-to-node-encryption skipped"></skipped>
+          </testcase>
+          <testcase name="seq-egress-gateway" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/egress-gateway (egress-gateway)"></property>
+              </properties>
+              <skipped message="seq-egress-gateway skipped"></skipped>
+          </testcase>
+          <testcase name="egress-gateway-excluded-cidrs" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/egress-gateway (egress-gateway-excluded-cidrs)"></property>
+              </properties>
+              <skipped message="egress-gateway-excluded-cidrs skipped"></skipped>
+          </testcase>
+          <testcase name="seq-egress-gateway-with-l7-policy" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/egress-gateway (egress-gateway)"></property>
+              </properties>
+              <skipped message="seq-egress-gateway-with-l7-policy skipped"></skipped>
+          </testcase>
+          <testcase name="pod-to-node-cidrpolicy" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-host)"></property>
+              </properties>
+              <skipped message="pod-to-node-cidrpolicy skipped"></skipped>
+          </testcase>
+          <testcase name="north-south-loadbalancing-with-l7-policy" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-lb (outside-to-nodeport)"></property>
+              </properties>
+              <skipped message="north-south-loadbalancing-with-l7-policy skipped"></skipped>
+          </testcase>
+          <testcase name="north-south-loadbalancing-with-l7-policy-port-range" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-lb (outside-to-nodeport)"></property>
+              </properties>
+              <skipped message="north-south-loadbalancing-with-l7-policy-port-range skipped"></skipped>
+          </testcase>
+          <testcase name="echo-ingress-l7" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod-with-endpoints)"></property>
+              </properties>
+              <skipped message="echo-ingress-l7 skipped"></skipped>
+          </testcase>
+          <testcase name="echo-ingress-l7-via-hostport" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-hostport)"></property>
+              </properties>
+              <skipped message="echo-ingress-l7-via-hostport skipped"></skipped>
+          </testcase>
+          <testcase name="echo-ingress-l7-named-port" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod-with-endpoints)"></property>
+              </properties>
+              <skipped message="echo-ingress-l7-named-port skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-l7-method" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod-with-endpoints)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod-with-endpoints)"></property>
+              </properties>
+              <skipped message="client-egress-l7-method skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-l7-method-port-range" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod-with-endpoints)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod-with-endpoints)"></property>
+              </properties>
+              <skipped message="client-egress-l7-method-port-range skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-l7" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/proxy (pod-to-world)"></property>
+              </properties>
+              <skipped message="client-egress-l7 skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-l7-port-range" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/proxy (pod-to-world)"></property>
+              </properties>
+              <skipped message="client-egress-l7-port-range skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-l7-named-port" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/proxy (pod-to-world)"></property>
+              </properties>
+              <skipped message="client-egress-l7-named-port skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-tls-sni" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/proxy (pod-to-world)"></property>
+              </properties>
+              <skipped message="client-egress-tls-sni skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-tls-sni-denied" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/proxy (pod-to-world)"></property>
+              </properties>
+              <skipped message="client-egress-tls-sni-denied skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-l7-tls-headers-sni" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/proxy (pod-to-world-with-tls-intercept)"></property>
+              </properties>
+              <skipped message="client-egress-l7-tls-headers-sni skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-l7-tls-headers-other-sni" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/proxy (pod-to-world-with-tls-intercept)"></property>
+              </properties>
+              <skipped message="client-egress-l7-tls-headers-other-sni skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-l7-set-header" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod-with-endpoints)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod-with-endpoints)"></property>
+              </properties>
+              <skipped message="client-egress-l7-set-header skipped"></skipped>
+          </testcase>
+          <testcase name="client-egress-l7-set-header-port-range" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod-with-endpoints)"></property>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod-with-endpoints)"></property>
+              </properties>
+              <skipped message="client-egress-l7-set-header-port-range skipped"></skipped>
+          </testcase>
+          <testcase name="echo-ingress-auth-always-fail" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="echo-ingress-auth-always-fail skipped"></skipped>
+          </testcase>
+          <testcase name="echo-ingress-auth-always-fail-port-range" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="echo-ingress-auth-always-fail-port-range skipped"></skipped>
+          </testcase>
+          <testcase name="echo-ingress-mutual-auth-spiffe" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="echo-ingress-mutual-auth-spiffe skipped"></skipped>
+          </testcase>
+          <testcase name="echo-ingress-mutual-auth-spiffe-port-range" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+              </properties>
+              <skipped message="echo-ingress-mutual-auth-spiffe-port-range skipped"></skipped>
+          </testcase>
+          <testcase name="pod-to-ingress-service" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-lb (pod-to-ingress-service)"></property>
+              </properties>
+              <skipped message="pod-to-ingress-service skipped"></skipped>
+          </testcase>
+          <testcase name="pod-to-ingress-service-allow-ingress-identity" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-lb (pod-to-ingress-service)"></property>
+              </properties>
+              <skipped message="pod-to-ingress-service-allow-ingress-identity skipped"></skipped>
+          </testcase>
+          <testcase name="pod-to-ingress-service-deny-all" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-lb (pod-to-ingress-service)"></property>
+              </properties>
+              <skipped message="pod-to-ingress-service-deny-all skipped"></skipped>
+          </testcase>
+          <testcase name="pod-to-ingress-service-deny-backend-service" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-lb (pod-to-ingress-service)"></property>
+              </properties>
+              <skipped message="pod-to-ingress-service-deny-backend-service skipped"></skipped>
+          </testcase>
+          <testcase name="pod-to-ingress-service-deny-ingress-identity" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-lb (pod-to-ingress-service)"></property>
+              </properties>
+              <skipped message="pod-to-ingress-service-deny-ingress-identity skipped"></skipped>
+          </testcase>
+          <testcase name="pod-to-ingress-service-deny-source-egress-other-node" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-lb (pod-to-ingress-service)"></property>
+              </properties>
+              <skipped message="pod-to-ingress-service-deny-source-egress-other-node skipped"></skipped>
+          </testcase>
+          <testcase name="outside-to-ingress-service" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-lb (outside-to-ingress-service)"></property>
+              </properties>
+              <skipped message="outside-to-ingress-service skipped"></skipped>
+          </testcase>
+          <testcase name="outside-to-ingress-service-deny-all-ingress" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-lb (outside-to-ingress-service)"></property>
+              </properties>
+              <skipped message="outside-to-ingress-service-deny-all-ingress skipped"></skipped>
+          </testcase>
+          <testcase name="outside-to-ingress-service-deny-cidr" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-lb (outside-to-ingress-service)"></property>
+              </properties>
+              <skipped message="outside-to-ingress-service-deny-cidr skipped"></skipped>
+          </testcase>
+          <testcase name="outside-to-ingress-service-deny-world-identity" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-lb (outside-to-ingress-service)"></property>
+              </properties>
+              <skipped message="outside-to-ingress-service-deny-world-identity skipped"></skipped>
+          </testcase>
+          <testcase name="dns-only" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod)"></property>
+                  <property name="owner" value="@cilium/proxy (pod-to-world)"></property>
+              </properties>
+              <skipped message="dns-only skipped"></skipped>
+          </testcase>
+          <testcase name="to-fqdns" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/proxy (pod-to-world)"></property>
+                  <property name="owner" value="@cilium/proxy (pod-to-world-2)"></property>
+              </properties>
+              <skipped message="to-fqdns skipped"></skipped>
+          </testcase>
+          <testcase name="pod-to-controlplane-host" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-controlplane-host)"></property>
+              </properties>
+              <skipped message="pod-to-controlplane-host skipped"></skipped>
+          </testcase>
+          <testcase name="pod-to-k8s-on-controlplane" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/ci-structure (pod-to-k8s-local)"></property>
+              </properties>
+              <skipped message="pod-to-k8s-on-controlplane skipped"></skipped>
+          </testcase>
+          <testcase name="pod-to-controlplane-host-cidr" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-controlplane-host)"></property>
+              </properties>
+              <skipped message="pod-to-controlplane-host-cidr skipped"></skipped>
+          </testcase>
+          <testcase name="pod-to-k8s-on-controlplane-cidr" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/ci-structure (pod-to-k8s-local)"></property>
+              </properties>
+              <skipped message="pod-to-k8s-on-controlplane-cidr skipped"></skipped>
+          </testcase>
+          <testcase name="local-redirect-policy" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-lb (lrp)"></property>
+                  <property name="owner" value="@cilium/sig-lb (lrp-skip-redirect-from-backend)"></property>
+              </properties>
+              <skipped message="local-redirect-policy skipped"></skipped>
+          </testcase>
+          <testcase name="local-redirect-policy-with-node-dns" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-lb (local-redirect-policy-with-node-dns)"></property>
+              </properties>
+              <skipped message="local-redirect-policy-with-node-dns skipped"></skipped>
+          </testcase>
+          <testcase name="pod-to-pod-no-frag" classname="connectivity test" status="failed" time="0.343417843">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod-no-frag)"></property>
+              </properties>
+              <failure message="pod-to-pod-no-frag failed" type="failure">pod-to-pod-no-frag/pod-to-pod-no-frag/ping-ipv4: cilium-test-1/client-59476dbc54-xxbg9 (10.244.1.83) -&gt; cilium-test-1/echo-other-node-d9bf5c4c7-97wkm (10.244.0.50:8080)&#xA;pod-to-pod-no-frag/pod-to-pod-no-frag/ping-ipv6: cilium-test-1/client-59476dbc54-xxbg9 (fd00:10:244:1::94c) -&gt; cilium-test-1/echo-other-node-d9bf5c4c7-97wkm (fd00:10:244::b1a1:8080)</failure>
+          </testcase>
+          <testcase name="seq-bgp-control-plane-v1" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-bgp (bgpv1-advertisements)"></property>
+              </properties>
+              <skipped message="seq-bgp-control-plane-v1 skipped"></skipped>
+          </testcase>
+          <testcase name="seq-bgp-control-plane-v2" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-bgp (bgpv2-advertisements)"></property>
+              </properties>
+              <skipped message="seq-bgp-control-plane-v2 skipped"></skipped>
+          </testcase>
+          <testcase name="multicast" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/ci-structure (multicast)"></property>
+              </properties>
+              <skipped message="multicast skipped"></skipped>
+          </testcase>
+          <testcase name="strict-mode-encryption" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod-missing-ipcache)"></property>
+              </properties>
+              <skipped message="strict-mode-encryption skipped"></skipped>
+          </testcase>
+          <testcase name="strict-mode-encryption-v2" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-pod-missing-ipcache)"></property>
+              </properties>
+              <skipped message="strict-mode-encryption-v2 skipped"></skipped>
+          </testcase>
+          <testcase name="host-firewall-ingress" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (pod-to-host)"></property>
+              </properties>
+              <skipped message="host-firewall-ingress skipped"></skipped>
+          </testcase>
+          <testcase name="host-firewall-egress" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (host-to-pod)"></property>
+              </properties>
+              <skipped message="host-firewall-egress skipped"></skipped>
+          </testcase>
+          <testcase name="seq-client-egress-l7-tls-deny-without-headers" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/proxy (pod-to-world-with-tls-intercept)"></property>
+              </properties>
+              <skipped message="seq-client-egress-l7-tls-deny-without-headers skipped"></skipped>
+          </testcase>
+          <testcase name="seq-client-egress-l7-tls-headers" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/proxy (pod-to-world-with-tls-intercept)"></property>
+              </properties>
+              <skipped message="seq-client-egress-l7-tls-headers skipped"></skipped>
+          </testcase>
+          <testcase name="seq-client-egress-l7-extra-tls-headers" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/proxy (pod-to-world-with-extra-tls-intercept)"></property>
+              </properties>
+              <skipped message="seq-client-egress-l7-extra-tls-headers skipped"></skipped>
+          </testcase>
+          <testcase name="seq-client-egress-l7-tls-headers-port-range" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/proxy (pod-to-world-with-tls-intercept)"></property>
+              </properties>
+              <skipped message="seq-client-egress-l7-tls-headers-port-range skipped"></skipped>
+          </testcase>
+          <testcase name="check-log-errors" classname="connectivity test" status="skipped" time="0">
+              <properties>
+                  <property name="owner" value="@cilium/sig-agent (no-errors-in-logs), @cilium/sig-datapath (no-errors-in-logs)"></property>
+              </properties>
+              <skipped message="check-log-errors skipped"></skipped>
+          </testcase>
+      </testsuite>
+  </testsuites>


### PR DESCRIPTION
Add support for handling a new form of codeowners information via properties on each test case. Compatible with https://github.com/cilium/cilium/pull/38710 .