### PR TITLE
junit: Do not require owners data to include test name

### DIFF
--- a/pkg/junit/junit_test.go
+++ b/pkg/junit/junit_test.go
@@ -82,6 +82,18 @@ func TestParseFile(t *testing.T) {
 			1,
 			nil,
 		},
+		{
+			"testdata/ci-privileged.xml",
+			7220,
+			0,
+			nil,
+		},
+		{
+			"testdata/unit-test.xml",
+			44,
+			1,
+			nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Log("Path: " + tt.path)

--- a/pkg/junit/junit_test.go
+++ b/pkg/junit/junit_test.go
@@ -90,9 +90,8 @@ func TestParseFile(t *testing.T) {
 		suites, cases, err := parseFile(f, dummyWorkflowRun, dummyConclusions, logger)
 		assert.ErrorIs(t, err, tt.expectedError)
 
-		assert.Equal(t, suites[0].TotalTests, tt.tests)
-		assert.Equal(t, len(cases), tt.tests)
-		assert.Equal(t, suites[0].TotalFailures, tt.failures)
+		assert.Equal(t, tt.tests, len(cases))
+		assert.Equal(t, tt.failures, suites[0].TotalFailures)
 	}
 }
 

--- a/pkg/junit/junit_test.go
+++ b/pkg/junit/junit_test.go
@@ -98,7 +98,7 @@ func TestParseFile(t *testing.T) {
 func TestParseFailureData(t *testing.T) {
 	input := "check-log-errors/no-errors-in-logs/kind-kind/kube-system/cilium-xxxxx (cilium-agent);metadata;Owners: @ci/owner1 (no-errors-in-logs), @ci/owner2 (no-errors-in-logs)"
 
-	owners, tests, err := parseFailureData(input)
+	owners, tests, err := parseFailureData("check-log-errors", input)
 	assert.NoError(t, err)
 	assert.Contains(t, owners, "@ci/owner1")
 	assert.Contains(t, owners, "@ci/owner2")
@@ -144,7 +144,7 @@ func TestParseProperties(t *testing.T) {
 func TestFilterOwners(t *testing.T) {
 	input := "check-log-errors/no-errors-in-logs/kind-kind/kube-system/cilium-xxxxx (cilium-agent);metadata;Owners: @ci/owner1 (no-errors-in-logs), @ci/owner2 (.github/foo)"
 
-	owners, tests, err := parseFailureData(input)
+	owners, tests, err := parseFailureData("check-log-errors", input)
 	assert.NoError(t, err)
 
 	testOwners := filterTestOwners(owners, tests)

--- a/pkg/junit/testdata/unit-test.xml
+++ b/pkg/junit/testdata/unit-test.xml
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="44" failures="1">
+	<testsuite name="github.com/cilium/cilium/pkg/ip" tests="44" failures="1" errors="0" id="0" hostname="joenats-l-PF4MRQR3" time="0.008" timestamp="2025-04-17T12:45:10-07:00">
+		<properties>
+			<property name="coverage.statements.pct" value="82.80"></property>
+		</properties>
+		<testcase name="TestIPToNetPrefix" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestPrefixesContains" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestPrefixesContains/contains([0.0.0.0/0],_192.0.0.1)" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestPrefixesContains/contains([0.0.0.0/0],_192.0.0.1)#01" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestPrefixesContains/contains([192.0.0.1/32_f00d::/118],_f00d::1)" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestPrefixesContains/contains([192.0.0.1/32],_0.0.0.0)" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestCountIPs" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestFirstIP" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestRemoveRedundant" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestRemoveCIDRs" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestRemoveSameCIDR" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestRemoveCIDRsEdgeCases" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestByteFunctions" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestIPNetToRange" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestNetsByRange" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestCoalesceCIDRs" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestRangeToCIDRs" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestPreviousIP" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestNextIP" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestCreateSpanningCIDR" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestPartitionCIDR" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestKeepUniqueAddrs" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestKeepUniqueAddrs/nil_slice" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestKeepUniqueAddrs/empty_slice" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestKeepUniqueAddrs/one_element_slice" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestKeepUniqueAddrs/IPv4_all_duplicates" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestKeepUniqueAddrs/IPv4_all_unique" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestKeepUniqueAddrs/IPv4_mixed" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestKeepUniqueAddrs/IPv6_all_duplicates" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestKeepUniqueAddrs/Mixed_IPv4_&amp;_IPv6" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestKeepUniqueAddrs/With_IPv6-in-IPv6" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestIPVersion" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestIPListEquals" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestGetIPFromListByFamily" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestGetIPAtIndex" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestMustAddrsFromIPs" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestPrefixToIpsValidIPv4" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestPrefixToIpsValidLimitedIPv4" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestPrefixToIpsValidIPv6" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestPrefixToIpsValidLimitedIPv6" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestPrefixToIPsInvalidPrefix" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestPrefixToIPv4sEdgeCase" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestPrefixToIpsWithMaxIPv4sExceedingRange" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="passed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+		</testcase>
+		<testcase name="TestFailure" classname="github.com/cilium/cilium/pkg/ip" time="0.000" status="failed">
+			<properties>
+				<property name="owner" value="@cilium/sig-agent"></property>
+			</properties>
+			<failure message="Failed"><![CDATA[    ip_test.go:1053: 
+        	Error Trace:	/var/git/cilium/pkg/ip/ip_test.go:1053
+        	Error:      	An error is expected but got nil.
+        	Test:       	TestFailure]]></failure>
+		</testcase>
+	</testsuite>
+</testsuites>


### PR DESCRIPTION
junit: Do not require owners data to include test name

So far we've been expecting the owners data to include a test name or
reference like `@cilium/sig-agent (test-name)`, but the test name is
already in the parent object. This commit loosens the requirement so
that other newer junit formats like the one to be generated as part of
unit testing do not need to provide the same form.
