### PR TITLE
github: Don't fetch error logs for skipped jobs

### DIFF
--- a/pkg/github/workflows.go
+++ b/pkg/github/workflows.go
@@ -501,7 +501,7 @@ func GetJobsAndStepsForRun(
 
 			job := types.NewJobRunFromRaw(run, jobRaw)
 
-			if job.Conclusion != "success" && includeErrorLogs {
+			if job.Conclusion != "success" && job.Conclusion != "skipped" && includeErrorLogs {
 				logs, err := GetLogsForJob(ctx, logger, client, job.ID, run.Repository.Owner.Login, run.Repository.Name)
 				if err != nil {
 					return nil, nil, err


### PR DESCRIPTION
It seems that some time around 2025-04-15T13:40Z, GitHub stopped serving
log results for jobs with the "skipped" conclusion. This caused corgi
scraping to regularly fail for scheduled workflows, because some
workflows like the Conformance EKS workflow always skips one job when
ran from this trigger. In order to resolve this, skip fetching error
logs for jobs whose conclusion is "skipped".

Signed-off-by: Joe Stringer <joe@isovalent.com>
