### PR TITLE
github/workflows: do not error in case of 404

### DIFF
--- a/pkg/github/workflows.go
+++ b/pkg/github/workflows.go
@@ -332,8 +332,9 @@ func GetLogsForJob(
 	)
 
 	if err != nil {
-		if logURLResp.StatusCode == 410 {
-			l.Warn("Logs for workflow run are unavailable, received status 410 Gone")
+		switch logURLResp.StatusCode {
+		case http.StatusNotFound, http.StatusGone:
+			l.Warn("Logs for workflow run are unavailable, received status", "http-code", logURLResp.StatusCode)
 
 			return "", nil
 		}


### PR DESCRIPTION
Instead of exiting the program in case of job logs not found, we should continue with the remaining jobs.