### PR TITLE
Track v1.19 branch

### DIFF
--- a/.github/scheduled.json
+++ b/.github/scheduled.json
@@ -7,12 +7,6 @@
       "events": "schedule,push"
     },
     {
-      "name": "cilium-cilium-1.15",
-      "repository": "cilium/cilium",
-      "branch": "v1.15",
-      "events": "workflow_dispatch,push"
-    },
-    {
       "name": "cilium-cilium-1.16",
       "repository": "cilium/cilium",
       "branch": "v1.16",
@@ -28,6 +22,12 @@
       "name": "cilium-cilium-1.18",
       "repository": "cilium/cilium",
       "branch": "v1.18",
+      "events": "workflow_dispatch,push"
+    },
+    {
+      "name": "cilium-cilium-1.19",
+      "repository": "cilium/cilium",
+      "branch": "v1.19",
       "events": "workflow_dispatch,push"
     },
     {


### PR DESCRIPTION
Scrape results from the newly created v1.19 branch and retire the
scraping for v1.15 which is well past EOL.

Signed-off-by: Joe Stringer <joe@isovalent.com>
