### PR TITLE
junit: Support scientific notation for time

### DIFF
--- a/pkg/junit/junit.go
+++ b/pkg/junit/junit.go
@@ -9,8 +9,10 @@ import (
 	"io/fs"
 	"log/slog"
 	"maps"
+	"math"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -109,6 +111,19 @@ func parseTime(timestamp string) (result time.Time, err error) {
 	return result, err
 }
 
+// parseDuration is wrapper for time.Duration that also supports parsing
+// scientific notation.
+func parseDuration(raw string) (time.Duration, error) {
+	seconds, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, err
+	}
+	if math.IsNaN(seconds) || math.IsInf(seconds, 0) {
+		seconds = 0
+	}
+	return time.Duration(seconds * float64(time.Second)), nil
+}
+
 func parseTestsuite(
 	suite *Testsuite,
 	run *types.WorkflowRun,
@@ -126,9 +141,9 @@ func parseTestsuite(
 	}
 
 	if suite.Time != "" {
-		duration, err := time.ParseDuration(fmt.Sprintf("%ss", suite.Time))
+		duration, err := parseDuration(suite.Time)
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to parse duration '%ss': %w", suite.Time, err)
+			return nil, nil, fmt.Errorf("unable to parse duration '%s': %w", suite.Time, err)
 		}
 		s.Duration = duration
 	}
@@ -198,9 +213,9 @@ func parseTestsuite(
 		}
 
 		if testcase.Time != "" {
-			duration, err := time.ParseDuration(fmt.Sprintf("%ss", testcase.Time))
+			duration, err := parseDuration(testcase.Time)
 			if err != nil {
-				return nil, nil, fmt.Errorf("unable to parse duration '%ss': %w", testcase.Time, err)
+				return nil, nil, fmt.Errorf("unable to parse duration '%s': %w", testcase.Time, err)
 			}
 			tc.Duration = duration
 		}

--- a/pkg/junit/junit_test.go
+++ b/pkg/junit/junit_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -208,4 +209,36 @@ func TestFilterOwners(t *testing.T) {
 	wfOwners := filterWorkflowOwners(owners, tests)
 	assert.Contains(t, wfOwners, "@ci/owner2")
 	assert.Len(t, wfOwners, 1)
+}
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected time.Duration
+	}{
+		{
+			name:     "integer",
+			input:    "15",
+			expected: 15 * time.Second,
+		},
+		{
+			name:     "decimal",
+			input:    "0.154",
+			expected: 154 * time.Millisecond,
+		},
+		{
+			name:     "scientific-notation",
+			input:    "4.7539e-05",
+			expected: 47539 * time.Nanosecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDuration(tt.input)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
 }


### PR DESCRIPTION
Marc and MPL report that the Cilium testsuite may emit junit test results with
durations measured in the microseconds, using scientific notation. The parser
to date assumed the input was in decimal seconds. Update the parser to accept
scientific notation for durations.

> level=ERROR msg="Unable to parse test cases for workflow run"
  event=push status=success workflow-id=22480861372 run=22480861372
  err="unable to parse test suite in junit file '...':
    unable to parse duration '4.7539e-05s':
      time: unknown unit \"e-\" in duration \"4.7539e-05s\""

Ref: https://github.com/isovalent/corgi/actions/runs/22484829573/job/65131741145#step:4:428
