### PR TITLE
junit: skip malformed files instead of aborting the scrape

### DIFF
--- a/pkg/junit/junit.go
+++ b/pkg/junit/junit.go
@@ -24,6 +24,13 @@ var (
 	ErrInvalidFailureData = errors.New("unsupported format for testcase.failure.data")
 	ErrUnbalancedOwners   = errors.New("expected list of '@<owner> (<test>)'")
 
+	// ErrMalformedFile marks a JUnit file whose *content* is unparseable
+	// (invalid XML or invalid testsuite fields). Such a file is recoverable on
+	// a per-file basis, so callers skip it and continue with the remaining
+	// files. It deliberately does NOT wrap open/read errors, which are systemic
+	// and must still abort the scrape.
+	ErrMalformedFile = errors.New("malformed junit file")
+
 	metadataDelimiter   = ";metadata;"
 	reFailureDataOwners = regexp.MustCompile(`@[-a-zA-Z\/0-9]*`)
 	reFailureDataTests  = regexp.MustCompile(`\(([-a-zA-Z\/0-9.]*)\)`)
@@ -314,7 +321,7 @@ func parseFile(
 		s := Testsuite{}
 		if err2 := xml.Unmarshal(buf.Bytes(), &s); err2 != nil {
 			e := errors.Join(err, err2)
-			return nil, nil, fmt.Errorf("unable to unmarshal junit file '%s' in artifact to Testsuite or Testsuites object: %w", fil.FileInfo().Name(), e)
+			return nil, nil, fmt.Errorf("%w: unable to unmarshal junit file '%s' in artifact to Testsuite or Testsuites object: %w", ErrMalformedFile, fil.FileInfo().Name(), e)
 		}
 		toParse = append(toParse, s)
 	} else {
@@ -324,7 +331,7 @@ func parseFile(
 	for _, s := range toParse {
 		parsedSuite, parsedCases, err := parseTestsuite(&s, run, allowedTestConclusions, l)
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to parse test suite in junit file '%s': %w", fil.FileInfo().Name(), err)
+			return nil, nil, fmt.Errorf("%w: unable to parse test suite in junit file '%s': %w", ErrMalformedFile, fil.FileInfo().Name(), err)
 		}
 
 		parsedSuite.JUnitFilename = fil.FileInfo().Name()
@@ -347,6 +354,14 @@ func ParseFiles[F file](
 	for _, f := range files {
 		s, c, err := parseFile(f, run, allowedTestConclusions, l)
 		if err != nil {
+			// A single malformed file (e.g. a JUnit report truncated because
+			// the upstream test run was interrupted mid-write) should not
+			// discard the remaining good files in the same artifact. Skip it
+			// and continue. Open/read errors are systemic and still abort.
+			if errors.Is(err, ErrMalformedFile) {
+				l.Warn("Skipping malformed JUnit file, continuing with remaining files", "file", f.FileInfo().Name(), "error", err)
+				continue
+			}
 			return nil, nil, err
 		}
 		suites = append(suites, s...)

--- a/pkg/junit/junit_test.go
+++ b/pkg/junit/junit_test.go
@@ -1,6 +1,7 @@
 package junit
 
 import (
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -124,6 +125,60 @@ func TestParseFile(t *testing.T) {
 		assert.Equal(t, tt.tests, len(cases))
 		assert.Equal(t, tt.failures, suites[0].TotalFailures)
 	}
+}
+
+func TestParseFileMalformed(t *testing.T) {
+	// A JUnit report truncated because the upstream test run was interrupted
+	// mid-write (unclosed <testsuite>) must be reported as ErrMalformedFile so
+	// that callers can skip it and keep the remaining files.
+	f, err := NewTestFile("testdata/malformed-unclosed-testsuite.xml")
+	assert.NoError(t, err)
+
+	_, _, err = parseFile(f, dummyWorkflowRun, dummyConclusions, logger)
+	assert.ErrorIs(t, err, ErrMalformedFile)
+}
+
+// errOpenFile is a file whose content is never reachable because Open fails.
+// It is used to prove open/read errors remain fatal (not skipped).
+type errOpenFile struct {
+	info os.FileInfo
+}
+
+func (e errOpenFile) FileInfo() os.FileInfo        { return e.info }
+func (e errOpenFile) Open() (io.ReadCloser, error) { return nil, errors.New("boom") }
+
+func TestParseFilesSkipsMalformed(t *testing.T) {
+	// A slice of [good, malformed, good] must parse successfully, skipping only
+	// the malformed file and preserving both good files' suites and cases.
+	good1, err := NewTestFile("testdata/connectivity-test.xml") // 1 suite, 119 cases
+	assert.NoError(t, err)
+	bad, err := NewTestFile("testdata/malformed-unclosed-testsuite.xml")
+	assert.NoError(t, err)
+	good2, err := NewTestFile("testdata/ci-eks-passed.xml") // 1 suite, 114 cases
+	assert.NoError(t, err)
+
+	suites, cases, err := ParseFiles(
+		[]testFile{good1, bad, good2},
+		dummyWorkflowRun, dummyConclusions, logger,
+	)
+	assert.NoError(t, err)
+	assert.Len(t, suites, 2)
+	assert.Len(t, cases, 119+114)
+}
+
+func TestParseFilesOpenErrorIsFatal(t *testing.T) {
+	// Open/read errors are systemic and must still abort, not be skipped.
+	good, err := NewTestFile("testdata/connectivity-test.xml")
+	assert.NoError(t, err)
+
+	suites, cases, err := ParseFiles(
+		[]file{good, errOpenFile{info: good.FileInfo()}},
+		dummyWorkflowRun, dummyConclusions, logger,
+	)
+	assert.Error(t, err)
+	assert.NotErrorIs(t, err, ErrMalformedFile)
+	assert.Nil(t, suites)
+	assert.Nil(t, cases)
 }
 
 func TestParseFailureData(t *testing.T) {

--- a/pkg/junit/testdata/malformed-unclosed-testsuite.xml
+++ b/pkg/junit/testdata/malformed-unclosed-testsuite.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuites tests="3" disabled="0" errors="0" failures="0" time="1.5">
+      <testsuite name="connectivity test" id="0" package="cilium" tests="3" errors="0" failures="0" skipped="0" time="1.5" timestamp="0001-01-01T00:00:00">
+          <testcase name="test-a" classname="connectivity test" status="passed" time="0.5"></testcase>
+          <testcase name="test-b" classname="connectivity test" status="passed" time="0.5"></testcase>
+          <testcase name="test-c" classname="connectivity test" status="passed" time="0.5">


### PR DESCRIPTION
A single JUnit file whose content cannot be parsed (for example a report truncated because the upstream test run was interrupted mid-write, leaving an unclosed <testsuite> element) caused ParseFiles to return an error on the first bad file, which the caller treated as fatal and exited on. One corrupt file in one artifact therefore discarded every other good file in the same artifact and aborted the scrape for the whole branch and window.

Introduce an ErrMalformedFile sentinel and wrap only the content-parse failures (XML unmarshal and testsuite parsing) with it. ParseFiles now logs and skips a malformed file and continues with the rest, while open/read errors stay fatal since they are systemic rather than per-file.

Also related with https://github.com/isovalent/corgi/issues/28