### PR TITLE
github: add scheduled retention for the runs indices

### DIFF
--- a/.github/opensearch/README.md
+++ b/.github/opensearch/README.md
@@ -1,0 +1,102 @@
+# OpenSearch retention for the runs index
+
+corgi scrapes GitHub Actions workflow runs into the `runs-oss` OpenSearch index.
+With no retention, that index grows unbounded until the data node crosses its
+flood-stage disk watermark (default 95%). OpenSearch then applies a
+`read-only-allow-delete` block on the index and every bulk write is rejected
+with `cluster_block_exception`, the failure seen in
+[actions/runs/28184337085](https://github.com/isovalent/corgi/actions/runs/28184337085).
+
+To prevent recurrence without renaming the index or changing how corgi writes, a
+scheduled job trims documents older than the retention window and reclaims the
+freed space. The index stays a concrete `runs-oss`, so the scrape and rates
+pipelines are unchanged.
+
+The enterprise `runs-cee` index is scraped by the workflows in
+[isovalent/corgi-cee](https://github.com/isovalent/corgi-cee) and is trimmed by
+the equivalent workflow there.
+
+## Retention key
+
+Every document corgi writes (`WorkflowRun`, `JobRun`, `StepRun`, `Testsuite`
+and `Testcase`) embeds the parent workflow run, so all of them carry the
+`workflow_run_started_at` field. A single `delete_by_query` on that field
+therefore trims every document type cleanly, with no orphaned child docs.
+
+## Automated trim
+
+The [`.github/workflows/retention-runs.yaml`](../workflows/retention-runs.yaml)
+workflow runs daily and invokes
+[`.github/scripts/trim-runs-index.sh`](../scripts/trim-runs-index.sh), which for
+each index given on the command line:
+
+1. `POST <index>/_delete_by_query` for docs with
+   `workflow_run_started_at < now-<RETENTION_DAYS>d` (default 190d), then
+2. `POST <index>/_forcemerge?only_expunge_deletes=true` to reclaim disk from
+   the deleted docs (a delete only marks docs; space is freed on merge).
+
+Adjust the `indices`, `retention-days` and `dry-run` inputs to run it ad hoc, or
+change the `env` defaults to trade history for disk. A failure on one index does
+not stop the others.
+
+The script can also be run locally, which is the easiest way to try a different
+retention window before changing the workflow. `DRY_RUN=true` only counts the
+matching documents and deletes nothing:
+
+```
+OPENSEARCH_URL=https://opensearch.example.com \
+OPENSEARCH_USER=user OPENSEARCH_PASS=pass \
+RETENTION_DAYS=190 DRY_RUN=true \
+  ./.github/scripts/trim-runs-index.sh runs-oss
+```
+
+## Manual run (in a browser)
+
+Open OpenSearch Dashboards, then Dev Tools, then Console (you are authenticated
+via your Dashboards login, no credentials needed) and run the following. The
+examples use `now-90d/d`; change the window to match your retention (the
+automated workflow defaults to 190 days):
+
+```
+# How much disk / how many docs are we talking about?
+GET _cat/indices/runs-oss?v&h=index,docs.count,store.size
+GET runs-oss/_count
+{ "query": { "range": { "workflow_run_started_at": { "lt": "now-90d/d" } } } }
+
+# Delete old docs. conflicts=proceed so concurrent scrapes don't abort it.
+POST runs-oss/_delete_by_query?conflicts=proceed&wait_for_completion=false
+{ "query": { "range": { "workflow_run_started_at": { "lt": "now-90d/d" } } } }
+
+# The previous call returns a task id; watch it to completion.
+GET _tasks/<task-id-from-response>
+
+# Reclaim disk from the deleted docs.
+POST runs-oss/_forcemerge?only_expunge_deletes=true
+```
+
+## Recovering if the index is already read-only (flood-stage block)
+
+If writes are currently rejected with `cluster_block_exception`:
+
+```
+# See which node is over the watermark and whether the block is set.
+GET _cat/allocation?v&h=node,disk.percent,disk.avail
+GET runs-oss/_settings/index.blocks.read_only_allow_delete
+
+# Deletes ARE allowed under the read-only-allow-delete block, so free space
+# first (this is the same trim query as above).
+POST runs-oss/_delete_by_query?conflicts=proceed&wait_for_completion=false
+{ "query": { "range": { "workflow_run_started_at": { "lt": "now-90d/d" } } } }
+POST runs-oss/_forcemerge?only_expunge_deletes=true
+
+# Clear the block with null (returns control to the disk monitor). On
+# OpenSearch / ES >= 7.4 the block also auto-releases once disk drops below the
+# HIGH watermark, so freeing space alone may suffice; this is a safety belt.
+PUT runs-oss/_settings
+{ "index.blocks.read_only_allow_delete": null }
+```
+
+Then re-run any failed scrape jobs via `workflow_dispatch`. Re-indexing is
+idempotent because corgi computes deterministic document `_id`s
+(`pkg/opensearch/bulk.go`), so backfilling overlapping windows overwrites rather
+than duplicates.

--- a/.github/scripts/trim-runs-index.sh
+++ b/.github/scripts/trim-runs-index.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# Trims documents older than a retention window from the given OpenSearch runs
+# indices and reclaims the freed disk space.
+#
+# Without retention these indices grow unbounded until the data node crosses its
+# flood-stage disk watermark, at which point OpenSearch marks the index
+# read-only and every bulk write from the scrape job fails. See
+# .github/opensearch/README.md.
+#
+# Usage:
+#   OPENSEARCH_URL=https://opensearch.example.com \
+#   OPENSEARCH_USER=user OPENSEARCH_PASS=pass \
+#   RETENTION_DAYS=190 [DRY_RUN=true] \
+#     .github/scripts/trim-runs-index.sh runs-oss [more-indices...]
+#
+# DRY_RUN=true only counts the matching documents and deletes nothing, which is
+# the safe way to try this out locally.
+
+set -uo pipefail
+
+: "${OPENSEARCH_URL:?OPENSEARCH_URL must be set}"
+: "${OPENSEARCH_USER:?OPENSEARCH_USER must be set}"
+: "${OPENSEARCH_PASS:?OPENSEARCH_PASS must be set}"
+: "${RETENTION_DAYS:?RETENTION_DAYS must be set}"
+DRY_RUN="${DRY_RUN:-false}"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <index> [index...]" >&2
+  exit 2
+fi
+
+if ! [[ "$RETENTION_DAYS" =~ ^[0-9]+$ ]]; then
+  echo "RETENTION_DAYS must be a positive integer, got '$RETENTION_DAYS'" >&2
+  exit 2
+fi
+
+cutoff="now-${RETENTION_DAYS}d/d"
+
+# Every document type corgi writes (WorkflowRun, JobRun, StepRun, Testsuite,
+# Testcase) embeds the parent workflow run, so all of them carry
+# workflow_run_started_at and this single query trims them together.
+query='{"query":{"range":{"workflow_run_started_at":{"lt":"'"$cutoff"'"}}}}'
+
+# curl wrapper. --fail-with-body makes curl exit non-zero on an HTTP error
+# while still printing the response body, so failures are both detectable and
+# debuggable. Credentials are passed via stdin-free env expansion rather than
+# being echoed by set -x.
+oscurl() {
+  curl -sS --fail-with-body \
+    -u "$OPENSEARCH_USER:$OPENSEARCH_PASS" \
+    -H "Content-Type: application/json" "$@"
+}
+
+# Trims a single index. Returns non-zero on failure so the caller can record it
+# and still continue with the remaining indices.
+trim_index() {
+  local index="$1"
+
+  echo "Index ${index} before trim:"
+  oscurl "${OPENSEARCH_URL}/_cat/indices/${index}?v&h=index,docs.count,docs.deleted,store.size" || true
+
+  # Capture curl and jq separately so a failed request is never mistaken for a
+  # document count.
+  local count_response match
+  if ! count_response=$(oscurl -XGET "${OPENSEARCH_URL}/${index}/_count" -d "$query"); then
+    echo "failed to count documents in ${index}: ${count_response}" >&2
+    return 1
+  fi
+  if ! match=$(printf '%s' "$count_response" | jq -er '.count'); then
+    echo "unexpected _count response for ${index}: ${count_response}" >&2
+    return 1
+  fi
+  echo "Documents older than ${RETENTION_DAYS}d (workflow_run_started_at < ${cutoff}) in ${index}: ${match}"
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "Dry run requested, not deleting."
+    return 0
+  fi
+
+  if [ "$match" -eq 0 ]; then
+    echo "Nothing to delete in ${index}."
+    return 0
+  fi
+
+  # conflicts=proceed so a concurrent scrape rewriting a document does not abort
+  # the whole delete. Documents skipped that way are picked up by the next run.
+  echo "Deleting ${match} documents from ${index}..."
+  local delete_response
+  if ! delete_response=$(oscurl -XPOST \
+    "${OPENSEARCH_URL}/${index}/_delete_by_query?conflicts=proceed&refresh=true" \
+    -d "$query"); then
+    echo "delete_by_query failed for ${index}: ${delete_response}" >&2
+    return 1
+  fi
+  printf '%s' "$delete_response" | jq '{deleted, version_conflicts, failures}'
+
+  local failures
+  failures=$(printf '%s' "$delete_response" | jq -r '.failures | length')
+  if [ "$failures" != "0" ]; then
+    echo "delete_by_query reported failures for ${index}" >&2
+    return 1
+  fi
+
+  # A delete only marks documents deleted, the disk they occupy is reclaimed
+  # when the segments holding them are merged.
+  echo "Reclaiming space in ${index} (force-merge only_expunge_deletes)..."
+  if ! oscurl -XPOST "${OPENSEARCH_URL}/${index}/_forcemerge?only_expunge_deletes=true" >/dev/null; then
+    echo "force-merge failed for ${index}" >&2
+    return 1
+  fi
+
+  echo "Index ${index} after trim:"
+  oscurl "${OPENSEARCH_URL}/_cat/indices/${index}?v&h=index,docs.count,docs.deleted,store.size" || true
+}
+
+rc=0
+for index in "$@"; do
+  if ! trim_index "$index"; then
+    echo "failed to trim ${index}" >&2
+    rc=1
+  fi
+done
+
+exit "$rc"

--- a/.github/workflows/retention-runs.yaml
+++ b/.github/workflows/retention-runs.yaml
@@ -1,0 +1,52 @@
+name: Trim old runs documents
+
+# Deletes documents older than RETENTION_DAYS from the runs index and reclaims
+# the freed disk, preventing the index from filling the OpenSearch data node and
+# tripping the flood-stage read-only block.
+# See .github/opensearch/README.md.
+
+on:
+  schedule:
+    - cron: "15 3 * * *"
+  workflow_dispatch:
+    inputs:
+      indices:
+        description: "Space-separated list of indices to trim"
+        required: false
+        type: string
+        default: "runs-oss"
+      retention-days:
+        description: "Delete documents older than this many days"
+        required: false
+        type: string
+        default: "190"
+      dry-run:
+        description: "Only count matching documents, do not delete"
+        required: false
+        type: boolean
+        default: false
+
+# The `inputs` context is only populated for workflow_dispatch, so the values
+# below are also what the scheduled run uses. Keep the fallbacks: without them
+# RETENTION_DAYS is empty on a schedule trigger and the cutoff becomes invalid.
+env:
+  TARGET_INDICES: ${{ inputs.indices || 'runs-oss' }}
+  RETENTION_DAYS: ${{ inputs.retention-days || '190' }}
+  DRY_RUN: ${{ inputs.dry-run || 'false' }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  trim:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Trim old documents and reclaim space
+        env:
+          OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+          OPENSEARCH_USER: ${{ secrets.OPENSEARCH_USER }}
+          OPENSEARCH_PASS: ${{ secrets.OPENSEARCH_PASS }}
+        run: |
+          ./.github/scripts/trim-runs-index.sh $TARGET_INDICES


### PR DESCRIPTION
The runs-oss index was never trimmed, so it grew unbounded until the OpenSearch data node crossed its flood-stage disk watermark (default 95%). OpenSearch then applied a read-only-allow-delete block on the index, and every bulk write from the scrape job failed with cluster_block_exception, as seen in https://github.com/isovalent/corgi/actions/runs/28184337085.

This adds a daily workflow that deletes documents older than a retention window (190 days by default) and force-merges to reclaim the freed space. Every document type corgi writes (WorkflowRun, JobRun, StepRun, Testsuite, Testcase) embeds the parent workflow run, so all of them carry workflow_run_started_at, and a single delete_by_query on that field trims them together with no orphaned child docs. Because it runs daily, it only ever removes a day of documents at a time, which keeps the index bounded.

The logic lives in .github/scripts/trim-runs-index.sh rather than inline in the workflow so that it can be reviewed as a normal shell script and run locally, with DRY_RUN=true to count the matching documents without deleting anything. The index stays a concrete runs-oss, so the scrape and rates pipelines are unchanged, and the indices, retention-days and dry-run inputs allow ad-hoc runs via workflow_dispatch. The manual trim and the recovery steps for an already read-only index are documented under .github/opensearch/README.md.

The enterprise runs-cee index is handled by the equivalent workflow in isovalent/corgi-cee, so this repository only ever touches the OSS index.

Note that merging this activates the daily schedule; until then the index is not auto-trimmed.