### PR TITLE
Track v1.20 branch

### DIFF
--- a/.github/scheduled.json
+++ b/.github/scheduled.json
@@ -7,18 +7,6 @@
       "events": "schedule,push"
     },
     {
-      "name": "cilium-cilium-1.16",
-      "repository": "cilium/cilium",
-      "branch": "v1.16",
-      "events": "workflow_dispatch,push"
-    },
-    {
-      "name": "cilium-cilium-1.17",
-      "repository": "cilium/cilium",
-      "branch": "v1.17",
-      "events": "workflow_dispatch,push"
-    },
-    {
       "name": "cilium-cilium-1.18",
       "repository": "cilium/cilium",
       "branch": "v1.18",
@@ -28,6 +16,12 @@
       "name": "cilium-cilium-1.19",
       "repository": "cilium/cilium",
       "branch": "v1.19",
+      "events": "workflow_dispatch,push"
+    },
+    {
+      "name": "cilium-cilium-1.20",
+      "repository": "cilium/cilium",
+      "branch": "v1.20",
       "events": "workflow_dispatch,push"
     },
     {


### PR DESCRIPTION
Scrape results for v1.20, and drop v1.16,v1.17 as they are now EOL.
