### PR TITLE
ci: complete GitHub Actions requirements

### DIFF
--- a/.github/workflows/retention-runs.yaml
+++ b/.github/workflows/retention-runs.yaml
@@ -42,7 +42,7 @@ jobs:
   trim:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Trim old documents and reclaim space
         env:
           OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}


### PR DESCRIPTION
## What changed

- Upgrade `actions/checkout` to `v7.0.1`.

## Files changed

- `.github/workflows/retention-runs.yaml`

## Why

This work addresses [isovalent/roadmap#3310](https://github.com/isovalent/roadmap/issues/3310).

GitHub Actions runners are moving to Node.js 24 and dropping older JavaScript runtimes. Updating these actions keeps the affected workflows operational after that transition.

External actions remain pinned to immutable commit SHAs so a mutable tag cannot change the workflow implementation without review.
